### PR TITLE
Fixing circular dependency on api service

### DIFF
--- a/apps/conduit/src/app/app.component.ts
+++ b/apps/conduit/src/app/app.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { environment } from '../environments/environment';
 import { AuthFacade, LocalStorageJwtService } from '@realworld/auth/data-access';
+import { API_URL } from '@realworld/core/http-client/src';
 import { filter, take } from 'rxjs/operators';
 import { FooterComponent } from './layout/footer/footer.component';
 import { NavbarComponent } from './layout/navbar/navbar.component';
@@ -12,6 +14,7 @@ import { NavbarComponent } from './layout/navbar/navbar.component';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
   imports: [FooterComponent, NavbarComponent, RouterModule, CommonModule],
+  providers: [{ provide: API_URL, useValue: environment.api_url }],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent implements OnInit {

--- a/libs/core/http-client/src/index.ts
+++ b/libs/core/http-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/api.service';
+export * from './lib/api-url.token';

--- a/libs/core/http-client/src/lib/api-url.token.ts
+++ b/libs/core/http-client/src/lib/api-url.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const API_URL = new InjectionToken<string>('API_URL');

--- a/libs/core/http-client/src/lib/api.service.ts
+++ b/libs/core/http-client/src/lib/api.service.ts
@@ -1,31 +1,31 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '@env/environment';
+import { API_URL } from './api-url.token';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, @Inject(API_URL) private api_url: string) {}
 
   get<T>(url: string, params: HttpParams = new HttpParams()): Observable<T> {
-    return this.http.get<T>(`${environment.api_url}${url}`, {
+    return this.http.get<T>(`${this.api_url}${url}`, {
       headers: this.headers,
       params,
     });
   }
 
   post<T, D>(url: string, data?: D): Observable<T> {
-    return this.http.post<T>(`${environment.api_url}${url}`, JSON.stringify(data), { headers: this.headers });
+    return this.http.post<T>(`${this.api_url}${url}`, JSON.stringify(data), { headers: this.headers });
   }
 
   put<T, D>(url: string, data: D): Observable<T> {
-    return this.http.put<T>(`${environment.api_url}${url}`, JSON.stringify(data), {
+    return this.http.put<T>(`${this.api_url}${url}`, JSON.stringify(data), {
       headers: this.headers,
     });
   }
 
   delete<T>(url: string): Observable<T> {
-    return this.http.delete<T>(`${environment.api_url}${url}`, {
+    return this.http.delete<T>(`${this.api_url}${url}`, {
       headers: this.headers,
     });
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "affected:lint": "nx affected:lint",
     "affected:dep-graph": "nx affected:dep-graph",
     "affected": "nx affected",
-    "format": "nx format:write",
+    "format": "nx format:write --base=main",
     "format:write": "nx format:write",
     "format:check": "nx format:check",
     "update": "nx migrate latest",


### PR DESCRIPTION
1. Change the way api_url is provided to the api.service as mentioned on #92 
2. Changed package.json command `nx format:write` to reference the main branch. (It defaults to master and master does not exist).