### PR TITLE
chore(tests): add e2e test for Settings

### DIFF
--- a/apps/conduit-e2e/src/integration/settings.feature
+++ b/apps/conduit-e2e/src/integration/settings.feature
@@ -1,0 +1,20 @@
+Feature: Settings
+
+    As a user,
+    I want to be able to update my account settings.
+
+    Background:
+        Given I am logged in to the system
+        And I open Settings page
+        And I wait for current username to appear
+
+    Scenario: Successfull settings update
+        When I input new username
+        And I input new bio
+        And I click Update Settings button
+        Then I am redirected to profile
+        Then my new username is displayed in the header
+        Then I open Settings page
+        Then I see new username
+        Then I see new bio
+

--- a/apps/conduit-e2e/src/integration/settings/settings.ts
+++ b/apps/conduit-e2e/src/integration/settings/settings.ts
@@ -1,0 +1,56 @@
+import { Given, When, And, Then } from 'cypress-cucumber-preprocessor/steps';
+import { generateRandomString } from '../../support/generate-random-string';
+
+let userId = '';
+let newUserId = '';
+let bio = '';
+
+beforeEach(() => {
+  userId = generateRandomString();
+  newUserId = generateRandomString();
+  bio = generateRandomString();
+});
+
+Given('I am logged in to the system', () => {
+  cy.loginApi(userId);
+});
+
+And('I open Settings page', () => {
+  cy.visit('/settings');
+});
+
+And('I wait for current username to appear', () => {
+  cy.get("[placeholder='Your Name']").should('have.value', userId);
+});
+
+When('I input new username', () => {
+  cy.get("[placeholder='Your Name']").clear().type(newUserId);
+});
+
+And('I input new bio', () => {
+  cy.get("[placeholder='Short bio about you']").clear().type(bio);
+});
+
+And('I click Update Settings button', () => {
+  cy.contains('button', 'Update Settings').click();
+});
+
+Then('I am redirected to profile', () => {
+  cy.url().should('include', '/profile');
+});
+
+Then('my new username is displayed in the header', () => {
+  cy.getByE2eId('logedin-user').should('contain', newUserId);
+});
+
+Then('I open Settings page', () => {
+  cy.visit('/settings');
+});
+
+Then('I see new username', () => {
+  cy.get("[placeholder='Your Name']").should('have.value', newUserId);
+});
+
+Then('I see new bio', () => {
+  cy.get("[placeholder='Short bio about you']").should('have.value', bio);
+});


### PR DESCRIPTION
This test reveals a bug with the settings feature. It exists in the original Angular repo too. The app has all kinds of strange behavior, like it's in the middle of a logged in and logged out state. The solution is to update the user token in `localStorage` after settings are updated. I am not sure exactly where to do that in this NgRx version, because I fixed it in my own fork which is refactoring from NgRx to the new Auto Signals pattern I came up with in this article: https://dev.to/mfp22/introducing-the-auto-signal-pattern-1a5h

This test passes when the feature is working properly. 