### PR TITLE
Return url tree from authGuard instead of redirect manually

### DIFF
--- a/libs/auth/data-access/src/lib/services/auth-guard.spec.ts
+++ b/libs/auth/data-access/src/lib/services/auth-guard.spec.ts
@@ -5,6 +5,7 @@ import { LocalStorageJwtService } from './local-storage-jwt.service';
 import { of } from 'rxjs';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'cdt-test-comp',
@@ -14,6 +15,7 @@ class TestComponent {}
 
 describe('authGuard', () => {
   let storage: LocalStorageJwtService;
+  let router: Router;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -29,6 +31,7 @@ describe('authGuard', () => {
     });
 
     storage = TestBed.inject(LocalStorageJwtService);
+    router = TestBed.inject(Router);
   });
 
   it('should return true if the user is logged in', () => {
@@ -37,11 +40,11 @@ describe('authGuard', () => {
     expect(result).toBeObservable(cold('(a|)', { a: true }));
   });
 
-  it('should return false if the user is not logged in', () => {
+  it('should return login urlTree if the user is not logged in', () => {
     jest.spyOn(storage, 'getItem').mockImplementationOnce(() => of(null));
 
     const result = TestBed.runInInjectionContext(() => authGuard());
 
-    expect(result).toBeObservable(cold('(a|)', { a: false }));
+    expect(result).toBeObservable(cold('(a|)', { a: router.parseUrl('/login') }));
   });
 });

--- a/libs/auth/data-access/src/lib/services/auth-guard.ts
+++ b/libs/auth/data-access/src/lib/services/auth-guard.ts
@@ -1,18 +1,17 @@
 import { inject } from '@angular/core';
-import { Router } from '@angular/router';
-import { map, take } from 'rxjs';
+import { map, Observable, take } from 'rxjs';
+import { Router, UrlTree } from '@angular/router';
 
 import { LocalStorageJwtService } from './local-storage-jwt.service';
 
-export const authGuard = () => {
-  const router = inject(Router);
+export const authGuard = (): Observable<boolean | UrlTree> => {
   const storage = inject(LocalStorageJwtService);
+  const router = inject(Router);
 
   return storage.getItem().pipe(
     map((token) => {
       if (!token) {
-        router.navigate(['/login']);
-        return false;
+        return router.parseUrl('/login');
       }
       return true;
     }),


### PR DESCRIPTION
According to Angular documentation https://angular.io/api/router/CanActivate we can directly return urlTree and that urlTree will be used as redirect. There is no need to manually redirect and return false.